### PR TITLE
MathProgBase wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,17 +112,21 @@ Method                          | Notes
 `jth_con(nlp, x, j)`            | Evaluate the `j`-th constraint at `x`
 `jth_congrad(nlp, x, j)`        | Evaluate the `j`-th constraint gradient at `x`
 `jth_sparse_congrad(nlp, x, j)` | Evaluate the `j`-th constraint sparse gradient at `x`
-`jac(nlp, x)`                   | Evaluate the sparse Jacobian of the constraints at `x`
+`jac(nlp, x)`                   | Evaluate the sparse Jacobian of the constraints at `x` in triplet format
 `hprod(nlp, x, v, y=y0, w=1)`   | Evaluate the product of the Hessian of the Lagrangian at (`x`,`y`) with `v` using the objective weight `w`
 `jth_hprod(nlp, x, v, j)`       | Compute the product of the Hessian of the `j`-th constraint at `x` with `v`
 `ghjvprod(nlp, x, g, v)`        | Compute the vector of dot products (`g`, `Hj*v`)
-`hess(nlp, x, y=y0, w=1.)`      | Evaluate the sparse Hessian of the Lagrangian at (`x`,`y`) using the objective weight `w`
+`hess(nlp, x, y=y0, w=1.)`      | Evaluate the sparse Hessian of the Lagrangian at (`x`,`y`) using the objective weight `w` in triplet format
 `write_sol(nlp, msg, x, y)`     | Write primal and dual solutions to file
 
 ## Missing Methods
 
 * methods for LPs (sparse cost, sparse contraint matrix)
 * methods to check optimality conditions.
+
+## Interface with MathProgBase
+
+The ampl.jl package implements the [nonlinear MathProgBase interface](http://mathprogbasejl.readthedocs.org/en/latest/nlp.html) as an ``AbstractNLPEvaluator``. If you are writing a solver in Julia, we recommend that the solver be written using this interface for problem input; in this case your solver will be accessible from multiple modeling packages including AMPL and [JuMP](https://github.com/JuliaOpt/JuMP.jl). See ``ampl_ipopt.jl`` for an example of how to use AMPL to call a solver that implements the nonlinear MathProgBase interface.
 
 ## Todo
 

--- a/ampl.jl
+++ b/ampl.jl
@@ -304,7 +304,7 @@ function jac(nlp :: AmplModel, x :: Array{Float64,1})
   cols = Array(Int64, nlp.nnzj)
   vals = Array(Float64, nlp.nnzj)
   @jampl_call(:jampl_jac, Void, (Ptr{Void}, Ptr{Float64}, Ptr{Int64}, Ptr{Int64}, Ptr{Float64}), nlp.__asl, x, rows, cols, vals)
-  return sparse(rows, cols, vals, nlp.ncon, nlp.nvar)
+  return rows, cols, vals
 end
 
 function hprod(nlp :: AmplModel,
@@ -390,5 +390,5 @@ function hess(nlp :: AmplModel,
   @jampl_call(:jampl_hess, Void,
                                  (Ptr{Void}, Ptr{Float64}, Float64, Ptr{Int64}, Ptr{Int64}, Ptr{Float64}),
                                   nlp.__asl, y, obj_weight, rows, cols, vals)
-  return sparse(rows, cols, vals, nlp.nvar, nlp.nvar)
+  return rows, cols, vals
 end

--- a/ampl_ipopt.jl
+++ b/ampl_ipopt.jl
@@ -1,0 +1,29 @@
+# Example script to solve AMPL model with IPOPT.
+# Needs some restructuring to be callable from AMPL
+
+require("ampl.jl")
+require("ampl_mathprogbase.jl")
+
+using Ipopt
+import MathProgBase
+
+function solve_with_ipopt(nlfile::ASCIIString)
+  nlp = AmplModel(nlfile)
+  # options can be set here
+  m = MathProgBase.model(IpoptSolver())
+  loadamplproblem!(m, nlp)
+  MathProgBase.optimize!(m)
+
+  objval = MathProgBase.getobjval(m)
+  x = MathProgBase.getsolution(m)
+
+  println("Optimal value: $objval")
+  println("Solution: $x")
+  
+end
+
+if length(ARGS) != 1
+  error("Usage: julia ampl_ipopt.jl nlfile")
+end
+
+solve_with_ipopt(ascii(ARGS[1]))

--- a/ampl_mathprogbase.jl
+++ b/ampl_mathprogbase.jl
@@ -1,0 +1,64 @@
+require(joinpath(Pkg.dir("MathProgBase"),"src","MathProgSolverInterface.jl"))
+
+import MathProgSolverInterface
+
+type AmplNLPEvaluator <: MathProgSolverInterface.AbstractNLPEvaluator
+  nlp::AmplModel
+end
+
+
+# ASL has methods to speed up initialization if certain functionalities aren't
+# needed. Currently we always request everything.
+MathProgSolverInterface.initialize(::AmplNLPEvaluator, requested_features) = nothing
+MathProgSolverInterface.features_available(::AmplNLPEvaluator) = [:Grad, :Jac, :HessVec, :Hess]
+
+MathProgSolverInterface.eval_f(d::AmplNLPEvaluator, x) = obj(d.nlp, x)
+
+MathProgSolverInterface.eval_g(d::AmplNLPEvaluator, g, x) = copy!(g, cons(d.nlp, x))
+
+MathProgSolverInterface.eval_grad_f(d::AmplNLPEvaluator, g, x) = copy!(g, grad(d.nlp, x))
+
+function MathProgSolverInterface.jac_structure(d::AmplNLPEvaluator)
+  rows, cols, vals = jac(d.nlp, d.nlp.x0)
+  return rows, cols
+end
+
+function MathProgSolverInterface.hesslag_structure(d::AmplNLPEvaluator)
+  rows, cols, vals = hess(d.nlp, d.nlp.x0, y=ones(d.nlp.ncon))
+  return rows, cols
+end
+
+
+function MathProgSolverInterface.eval_jac_g(d::AmplNLPEvaluator, J, x)
+  rows, cols, vals = jac(d.nlp, x)
+  copy!(J, vals)
+end
+
+# Are there specialized methods for Jac-vec products?
+# MathProgSolverInterface.eval_jac_prod(d::AmplNLPEvaluator, J, x)
+# MathProgSolverInterface.eval_jac_prod_t(d::AmplNLPEvaluator, J, x)
+
+
+function MathProgSolverInterface.eval_hesslag_prod(d::AmplNLPEvaluator, h, x, v, σ, μ)
+  obj(d.nlp, x) # force hessian evaluation at this point
+  result = hprod(d.nlp, x, v, y = -μ, obj_weight = σ)
+  copy!(h, result)
+end
+
+function MathProgSolverInterface.eval_hesslag(d::AmplNLPEvaluator, H, x, σ, μ)
+  obj(d.nlp, x) # force hessian evaluation at this point
+  rows, cols, vals = hess(d.nlp, x, y = -μ, obj_weight = σ)
+  copy!(H, vals)
+end
+
+# How do we extract this?
+#MathProgSolverInterface.isobjlinear(d::AmplNLPEvaluator)
+#MathProgSolverInterface.isobjquadratic(d::AmplNLPEvaluator)
+
+MathProgSolverInterface.isconstrlinear(d::AmplNLPEvaluator,i) = (i in d.nlp.lin)
+
+function loadamplproblem!(m::MathProgSolverInterface.AbstractMathProgModel, nlp::AmplModel)
+  sense = nlp.minimize ? :Min : :Max
+  MathProgSolverInterface.loadnonlinearproblem!(m, nlp.nvar, nlp.ncon, nlp.lvar, 
+    nlp.uvar, nlp.lcon, nlp.ucon, sense, AmplNLPEvaluator(nlp))
+end


### PR DESCRIPTION
Here's my attempt at a MathProgBase wrapper for AMPL.jl.

The `ampl_ipopt.jl` script calls Ipopt using it's MathProgBase interface. Seems to work on `rosenbr.nl`. Obviously not too practically useful because Ipopt has its own ASL interface, but it's a proof of concept.

There are a couple of places where I wasn't sure how to implement the methods; these are indicated with comments. 

The only modifications I needed to make to the core was returning the Jacobian and Hessian in sparse triplet form. The `sparse` function in Julia deletes structural zeros, which is problematic for detecting the sparsity pattern. I'd say this format is a bit simpler, and the user can easily call `sparse` if desired. If you'd prefer to keep the original functionality, I'll just need an alternative method to access the triplet form.

I also added some editorializing to the README, suggesting that solvers should be written using the MathProgBase interface instead of being tied to AMPL directly. This is just my opinion, but this policy would be a great step in the direction of interoperability between solvers and modeling interfaces in Julia. If you have a different view, we can certainly discuss the wording.

CC @IainNZ @joehuchette @tkelman
