### PR TITLE
Safe model

### DIFF
--- a/src/ampl_model.jl
+++ b/src/ampl_model.jl
@@ -27,8 +27,9 @@ type AmplModel <: AbstractNLPModel
   __asl :: Ptr{Void};        # Pointer to internal ASL structure. Do not touch.
 
   counters :: Counters       # Evaluation counters
+  safe :: Bool               # Always evaluate the objective before the Hessian.
 
-  function AmplModel(stub :: AbstractString)
+  function AmplModel(stub :: AbstractString; safe :: Bool=false)
     asl = @compat @asl_call(:asl_init, Ptr{Void}, (Ptr{UInt8},), stub);
     asl == C_NULL && error("Error allocating ASL structure")
 
@@ -90,7 +91,7 @@ type AmplModel <: AbstractNLPModel
                         nlin=nlin, nnln=nnln, nnet=nnet, nlnet=nlnet,
                         minimize=minimize, islp=islp, name=stub)
 
-    nlp = new(meta, asl, Counters())
+    nlp = new(meta, asl, Counters(), safe)
 
     finalizer(nlp, amplmodel_finalize)
     return nlp
@@ -384,12 +385,16 @@ function hprod!(nlp :: AmplModel,
                 hv :: Array{Float64,1};
                 y :: Array{Float64,1} = nlp.meta.y0,
                 obj_weight :: Float64 = 1.0)
-  # Note: x is in fact not used.
+  # Note: x is in fact not used in hprod.
   @check_ampl_model
   length(x) >= nlp.meta.nvar || error("x must have length at least $(nlp.meta.nvar)")
   length(y) >= nlp.meta.ncon || error("y must have length at least $(nlp.meta.ncon)")
   length(v) >= nlp.meta.nvar || error("v must have length at least $(nlp.meta.nvar)")
 
+  if nlp.safe
+    _ = obj(nlp, x) ; nlp.counters.neval_obj -= 1
+    _ = cons(nlp, x) ; nlp.counters.neval_cons -= 1
+  end
   @asl_call(:asl_hprod, Ptr{Float64},
             (Ptr{Void}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Float64),
              nlp.__asl, y,            v,            hv,           obj_weight);
@@ -412,12 +417,19 @@ The objective Hessian is used if `j=0`.
 function jth_hprod!(nlp :: AmplModel,
                     x :: Array{Float64,1}, v :: Array{Float64,1},
                     j :: Int, hv :: Array{Float64,1})
-  # Note: x is in fact not used.
+  # Note: x is in fact not used in hprod.
   @check_ampl_model
   length(x) >= nlp.meta.nvar || error("x must have length at least $(nlp.meta.nvar)")
   length(v) >= nlp.meta.nvar || error("v must have length at least $(nlp.meta.nvar)")
   (1 <= j <= nlp.meta.ncon)  || error("expected 0 ≤ j ≤ $(nlp.meta.ncon)")
 
+  if nlp.safe
+    if j == 0
+      _ = obj(nlp, x) ; nlp.counters.neval_obj -= 1
+    else
+      _ = cons(nlp, x) ; nlp.counters.neval_cons -= 1
+    end
+  end
   @asl_call(:asl_hvcompd, Ptr{Float64},
             (Ptr{Void}, Ptr{Float64}, Ptr{Float64}, Int),
              nlp.__asl, v,            hv,           j-1);
@@ -446,6 +458,9 @@ function ghjvprod!(nlp :: AmplModel,
   length(g) >= nlp.meta.nvar || error("g must have length at least $(nlp.meta.nvar)")
   length(v) >= nlp.meta.nvar || error("v must have length at least $(nlp.meta.nvar)")
 
+  if nlp.safe
+    _ = cons(nlp, x) ; nlp.counters.neval_cons -= 1
+  end
   @asl_call(:asl_ghjvprod, Ptr{Float64},
             (Ptr{Void}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
              nlp.__asl, g,            v,            gHv);
@@ -463,6 +478,11 @@ function hess_coord(nlp :: AmplModel,
   @check_ampl_model
   length(x) >= nlp.meta.nvar || error("x must have length at least $(nlp.meta.nvar)")
   length(y) >= nlp.meta.ncon || error("y must have length at least $(nlp.meta.ncon)")
+
+  if nlp.safe
+    _ = obj(nlp, x) ; nlp.counters.neval_obj -= 1
+    _ = cons(nlp, x) ; nlp.counters.neval_cons -= 1
+  end
 
   rows = Array(Int64, nlp.meta.nnzh)
   cols = Array(Int64, nlp.meta.nnzh)

--- a/src/ampl_model.jl
+++ b/src/ampl_model.jl
@@ -422,7 +422,6 @@ function jth_hprod!(nlp :: AmplModel,
             (Ptr{Void}, Ptr{Float64}, Ptr{Float64}, Int),
              nlp.__asl, v,            hv,           j-1);
   nlp.counters.neval_jhprod += 1
-  j > 0 && (hv *= -1)  # lagscale() flipped the sign of each constraint.
   return hv
 end
 
@@ -451,7 +450,6 @@ function ghjvprod!(nlp :: AmplModel,
             (Ptr{Void}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}),
              nlp.__asl, g,            v,            gHv);
   nlp.counters.neval_hprod += nlp.meta.ncon
-  gHv *= -1  # lagscale() flipped the sign of each constraint.
 end
 
 """Evaluate the Lagrangian Hessian at `(x,y)` in sparse coordinate format.

--- a/test/consistency.jl
+++ b/test/consistency.jl
@@ -10,7 +10,7 @@ for problem in problems
   include(joinpath(nlppath, "$problem_s.jl"))
 
   problem_f = eval(problem)
-  nlp_ampl = AmplModel(joinpath(testpath, "$problem_s.nl"))
+  nlp_ampl = AmplModel(joinpath(testpath, "$problem_s.nl"), safe=true)
   nlp_mpb = MathProgNLPModel(problem_f())
   nlps = [nlp_ampl, nlp_mpb]
 

--- a/test/consistency.jl
+++ b/test/consistency.jl
@@ -11,8 +11,8 @@ for problem in problems
 
   problem_f = eval(problem)
   nlp_ampl = AmplModel(joinpath(testpath, "$problem_s.nl"))
-  nlp_jump = JuMPNLPModel(problem_f())
-  nlps = [nlp_ampl, nlp_jump]
+  nlp_mpb = MathProgNLPModel(problem_f())
+  nlps = [nlp_ampl, nlp_mpb]
 
   @printf("Checking problem %-15s%12s\t", problem_s, "")
   consistent_nlps(nlps)


### PR DESCRIPTION
This PR defines safe mode for an AMPL model.

I also removed the contribution of `lagscale` to constraint Hessians. The thinking is that if c(x) is a constraint function, its Hessian does not depend on a scaling parameter used in the definition of the Lagrangian.