### PR TITLE
phase out MinGW in Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,34 +1,20 @@
 environment:
   matrix:
-  - MINGW_DIR: mingw64
-    JULIA_VER: 1.3
-    MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/seh/x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z/download
-    MINGW_ARCHIVE: x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z
-    JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.3/julia-1.3-latest-win64.exe"
+  - julia_version: 1.3
+  - julia_version: nightly
 
-  - MINGW_DIR: mingw32
-    JULIA_VER: 1.3
-    MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-win32/dwarf/i686-8.1.0-release-win32-dwarf-rt_v6-rev0.7z/download
-    MINGW_ARCHIVE: i686-8.1.0-release-win32-dwarf-rt_v6-rev0.7z
-    JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.3/julia-1.3-latest-win32.exe"
-
-  - MINGW_DIR: mingw64
-    JULIA_VER: nightly
-    MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/seh/x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z/download
-    MINGW_ARCHIVE: x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z
-    JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-
-  - MINGW_DIR: mingw32
-    JULIA_VER: nightly
-    MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-win32/dwarf/i686-8.1.0-release-win32-dwarf-rt_v6-rev0.7z/download
-    MINGW_ARCHIVE: i686-8.1.0-release-win32-dwarf-rt_v6-rev0.7z
-    JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
 
 matrix:
   allow_failures:
-    - MINGW_DIR: mingw32
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - julia_version: nightly
+
+branches:
+  only:
+    - master
+    - /release-.*/
 
 notifications:
   - provider: Email
@@ -36,27 +22,13 @@ notifications:
     on_build_failure: false
     on_build_status_changed: false
 
-branches:
-  only:
-    - master
-
-skip_branch_with_pr: true
-
 install:
-  - if not exist "%MINGW_ARCHIVE%" appveyor DownloadFile "%MINGW_URL%" -FileName "%MINGW_ARCHIVE%"
-  - 7z x -y "%MINGW_ARCHIVE%" > nul
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile($env:JULIA_URL, "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-  - set Path=%CD%\%MINGW_DIR%\bin;%Path%
-  - g++ --version
-  - mingw32-make --version
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "using Pkg; Pkg.clone(pwd(), \"AmplNLReader\"); Pkg.build(\"AmplNLReader\");"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "using Pkg; Pkg.test(\"AmplNLReader\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"


### PR DESCRIPTION
With precompiled binaries, I don't think we need MinGW anymore.