### PR TITLE
Fix detection of .nl extension

### DIFF
--- a/src/ampl_model.jl
+++ b/src/ampl_model.jl
@@ -27,7 +27,7 @@ mutable struct AmplModel <: AbstractNLPModel{Float64, Vector{Float64}}
 
     # check that stub or stub.nl exists
     fname = basename(stub)
-    ext = occursin(".", fname) ? split(fname, '.')[2] : ""
+    ext = occursin(".", fname) ? split(fname, '.')[end] : ""
     if ext == "nl"
       isfile(stub) || throw(AmplException("cannot find $(stub)"))
     else


### PR DESCRIPTION
I am currently working on the MacMPEC benchmark, and using AmplNLReader to import the instances implemented by [Sven Leyffer](https://wiki.mcs.anl.gov/leyffer/index.php/MacMPEC). 

I noticed I got an error if there is multiple dots `.` in the file name. E.g., 
```julia
filename = "ex9.1.1.nl"
nlp = AmplModel(filename)
```
returns the following error
```
ERROR: LoadError: AmplException("cannot find /home/fpacaud/Documents/benchmarks/MacMPEC/NL/ex9.1.10.nl.nl")
Stacktrace:
 [1] AmplModel(stub::String; safe::Bool)
   @ AmplNLReader ~/.julia/packages/AmplNLReader/2ThAP/src/ampl_model.jl:34
 [2] AmplModel(stub::String)
   @ AmplNLReader ~/.julia/packages/AmplNLReader/2ThAP/src/ampl_model.jl:26
```

This PR aims at fixing this issue. 