### PR TITLE
Add support for complementarity constraints

### DIFF
--- a/src/AmplNLReader.jl
+++ b/src/AmplNLReader.jl
@@ -12,5 +12,6 @@ const libasl = joinpath(dirname(ASL_jll.libasl_path), "libasl." * dlext)
 
 include("ampl_meta.jl")
 include("ampl_model.jl")
+include("ampl_mpec_model.jl")
 
 end  # Module AmplNLReader

--- a/src/ampl_meta.jl
+++ b/src/ampl_meta.jl
@@ -58,6 +58,8 @@ The following keyword arguments are accepted:
 - `minimize`: true if optimize == minimize
 - `nlo`: number of nonlinear objectives
 - `islp`: true if the problem is a linear program
+- `n_cc`: number of complementarity constraints
+- `cvar`: indices of variables appearing in complementarity constraints (0 if constraint is regular)
 - `name`: problem name
 """
 struct AmplNLPMeta <: AbstractNLPModelMeta{Float64, Vector{Float64}}
@@ -114,6 +116,8 @@ struct AmplNLPMeta <: AbstractNLPModelMeta{Float64, Vector{Float64}}
   minimize::Bool
   nlo::Int
   islp::Bool
+  n_cc::Int
+  cvar::Vector{Int}
   name::String
 
   function AmplNLPMeta(
@@ -148,6 +152,8 @@ struct AmplNLPMeta <: AbstractNLPModelMeta{Float64, Vector{Float64}}
     minimize = true,
     nlo = 1,
     islp = false,
+    n_cc = 0,
+    cvar = Int[],
     name = "Generic",
   )
     if (nvar < 1) || (ncon < 0)
@@ -159,6 +165,9 @@ struct AmplNLPMeta <: AbstractNLPModelMeta{Float64, Vector{Float64}}
     @lencheck nnnet nnet
     @lencheck nlnet lnet
     @rangecheck 1 ncon lin nln nnet lnet
+    if n_cc > 0
+        @lencheck ncon cvar
+    end
 
     ifix = findall(lvar .== uvar)
     ilow = findall((lvar .> -Inf) .& (uvar .== Inf))
@@ -226,6 +235,8 @@ struct AmplNLPMeta <: AbstractNLPModelMeta{Float64, Vector{Float64}}
       minimize,
       nlo,
       islp,
+      n_cc,
+      cvar,
       name,
     )
   end

--- a/src/ampl_mpec_model.jl
+++ b/src/ampl_mpec_model.jl
@@ -1,0 +1,445 @@
+export AmplMPECModel
+
+@doc raw"""
+    AmplMPECModel
+
+Smooth reformulation for an Ampl model with complementarity constraints.
+
+The nonlinear program
+```math
+\begin{aligned}
+       min_x  \quad &  f(x)\\
+\mathrm{s.t.} \quad &  c_L ≤ c(x) ≤ c_U,\\
+                    &  g_L ≤ g(x) ⟂ x ≥ x_L,
+\end{aligned}
+```
+is reformulated as
+```math
+\begin{aligned}
+       min_x  \quad &  f(x)\\
+\mathrm{s.t.} \quad &  c_L ≤ c(x) ≤ c_U,\\
+                    &  g_L ≤ g(x)  \\
+                    &  x_L ≤ x \\
+                    &  Diag(g(x)) x ≤ 0
+\end{aligned}
+```
+
+Return the original model if it does not have complementarity constraints.
+
+"""
+struct AmplMPECModel <: AbstractNLPModel{Float64, Vector{Float64}}
+  mp::AmplModel
+  meta::NLPModelMeta
+  counters::Counters
+  ind_cc_cons::Vector{Int}         # Dimension [m_cc]
+  buffer_c1::Vector{Float64}       # Dimension [m]
+  buffer_c2::Vector{Float64}       # Dimension [m]
+  buffer_vars::Vector{Float64}     # Dimension [n]
+  buffer_jac::Vector{Float64}      # Dimension [nnzj]
+  # Sparsity pattern of complementarity constraints in CSR format.
+  Jccp::Vector{Int}                # Dimension [m_cc]
+  Jccj::Vector{Int}                # Dimension [nnzj_cc]
+  Jccv::Vector{Int}                # Dimension [nnzj_cc]
+end
+
+function AmplMPECModel(mp::AmplModel)
+  if mp.meta.n_cc == 0
+    @warn("Model does not have any MPEC constraints, returning original model.")
+    return mp
+  end
+  n_cc = mp.meta.n_cc
+  cvar = mp.meta.cvar
+  ind_cc_cons = findall(cvar .> 0)
+  @lencheck mp.meta.n_cc ind_cc_cons
+
+  n = NLPModels.get_nvar(mp)
+  m = NLPModels.get_ncon(mp)
+  lvar = NLPModels.get_lvar(mp)
+  uvar = NLPModels.get_uvar(mp)
+  lcon = NLPModels.get_lcon(mp)
+  ucon = NLPModels.get_ucon(mp)
+  nnzj = NLPModels.get_nnzj(mp)
+
+  # Check MPEC model has been formatted by Ampl.
+  for i in 1:n_cc
+    ic = ind_cc_cons[i]
+    @assert isinf(uvar[cvar[ic]])
+    @assert isinf(ucon[ic])
+  end
+
+  buffer_c1 = zeros(m)
+  buffer_c2 = zeros(m)
+  buffer_vars = zeros(n)
+  buffer_jac = zeros(nnzj)
+
+  # Reverse mapping
+  cnt = 1
+  ind_cc = zeros(Int, m)
+  for i in 1:m
+    if cvar[i] > 0
+      ind_cc[i] = cnt
+      cnt += 1
+    end
+  end
+
+  # Get sparsity pattern of original problem.
+  rows = zeros(Int, nnzj)
+  cols = zeros(Int, nnzj)
+  NLPModels.jac_structure!(mp, rows, cols)
+  # Analyze sparsity pattern of complementarity constraints
+  cnt = 1
+  # Count number of nonzeroes in each row
+  Jccp = zeros(Int, n_cc+1)
+  # Terms Diag(x) * ∇g(x)
+  for (i, j) in zip(rows, cols)
+    if ind_cc[i] > 0
+      Jccp[ind_cc[i]] += 1
+    end
+  end
+  # Terms Diag(g(x))
+  Jccp[1:n_cc] .+= 1
+  nnzcc = sum(Jccp)
+  # Cumsum nnz per row
+  cnt = 1
+  for i in 1:n_cc
+    tmp = Jccp[i]
+    Jccp[i] = cnt
+    cnt += tmp
+  end
+  Jccp[n_cc+1] = nnzcc + 1
+  # Column indexes
+  Jccj = zeros(Int, nnzcc)
+  # Stores position in original Jacobian (-1 if terms associated to Diag(g(x)))
+  Jccv = zeros(Int, nnzcc)
+  # Terms Diag(x) * ∇g(x)
+  for k in 1:nnzj
+    i, j = rows[k], cols[k]
+    ic = ind_cc[i]
+    if cvar[i] > 0
+      dest = Jccp[ic]
+      Jccj[dest] = j
+      Jccv[dest] = k
+      Jccp[ic] += 1
+    end
+  end
+  # Terms Diag(g(x))
+  for i in 1:n_cc
+    ic = ind_cc_cons[i]
+    dest = Jccp[i]
+    Jccj[dest] = cvar[ic]
+    Jccv[dest] = -1   # store -1 as term is associated to Diag(g(x))
+    Jccp[i] += 1
+  end
+  # Reorder Jccp
+  last = 1
+  for i in 1:n_cc+1
+    tmp = Jccp[i]
+    Jccp[i] = last
+    last = tmp
+  end
+
+  lcon_cc = fill(-Inf, n_cc)
+  ucon_cc = fill( 0.0, n_cc)
+  # TODO: find a better initialization for complementarities' multipliers
+  y0_cc = fill(0.0, n_cc)
+
+  meta = NLPModels.NLPModelMeta(
+    n;
+    lvar=lvar,
+    uvar=uvar,
+    x0=NLPModels.get_x0(mp),
+    y0 = [NLPModels.get_y0(mp); y0_cc],
+    nnzj=NLPModels.get_nnzj(mp) + nnzcc,
+    nnzh=NLPModels.get_nnzh(mp) + nnzcc - n_cc,
+    ncon=m + n_cc,
+    lcon=[lcon; lcon_cc],
+    ucon=[ucon; ucon_cc],
+    minimize=mp.meta.minimize,
+    name="MPEC-" * mp.meta.name,
+  )
+
+  return AmplMPECModel(
+    mp,
+    meta,
+    Counters(),
+    ind_cc_cons,
+    buffer_c1,
+    buffer_c2,
+    buffer_vars,
+    buffer_jac,
+    Jccp,
+    Jccj,
+    Jccv,
+  )
+end
+
+function NLPModels.obj(nlp::AmplMPECModel, x::AbstractVector)
+  @lencheck nlp.meta.nvar x
+  return NLPModels.obj(nlp.mp, x)
+end
+
+function NLPModels.grad!(nlp::AmplMPECModel, x::AbstractVector, g::AbstractVector)
+  @lencheck nlp.meta.nvar x g
+  return NLPModels.grad!(nlp.mp, x, g)
+end
+
+function NLPModels.cons!(nlp::AmplMPECModel, x::AbstractVector, c::AbstractVector)
+  @lencheck nlp.meta.nvar x
+  @lencheck nlp.meta.ncon c
+
+  m = NLPModels.get_ncon(nlp.mp)
+  n_cc = nlp.mp.meta.n_cc
+  cvar = nlp.mp.meta.cvar
+  lcon = NLPModels.get_lcon(nlp.mp)
+  lvar = NLPModels.get_lvar(nlp.mp)
+  # Evaluate regular constraints
+  c_reg = nlp.buffer_c1
+  NLPModels.cons!(nlp.mp, x, c_reg)
+  c[1:m] .= c_reg
+  # Evaluate complementarity constraints
+  for i in 1:n_cc
+    ic = nlp.ind_cc_cons[i]
+    c[m + i] = (c[ic] - lcon[ic]) * (x[cvar[ic]] - lvar[cvar[ic]])
+  end
+  return c
+end
+
+function NLPModels.jac_structure!(
+  nlp::AmplMPECModel,
+  rows::AbstractVector{<:Integer},
+  cols::AbstractVector{<:Integer},
+)
+  n = NLPModels.get_nvar(nlp.mp)
+  m = NLPModels.get_ncon(nlp.mp)
+  nnzj = NLPModels.get_nnzj(nlp.mp)
+  rows_reg, cols_reg = view(rows, 1:nnzj), view(cols, 1:nnzj)
+  NLPModels.jac_structure!(nlp.mp, rows_reg, cols_reg)
+
+  n_cc = nlp.mp.meta.n_cc
+  cvar = nlp.mp.meta.cvar
+
+  # Sparsity pattern of complementarity constraints is encoded
+  # in CSR format in (Jccp, Jccj)
+  cnt = nnzj
+  for i in 1:n_cc
+    for k in nlp.Jccp[i]:nlp.Jccp[i+1]-1
+      cnt += 1
+      rows[cnt] = i + m
+      cols[cnt] = nlp.Jccj[k]
+    end
+  end
+
+  return rows, cols
+end
+
+function NLPModels.jac_coord!(
+  nlp::AmplMPECModel,
+  x::AbstractVector,
+  vals::AbstractVector,
+)
+  @lencheck nlp.meta.nvar x
+  @lencheck nlp.meta.nnzj vals
+
+  n = NLPModels.get_nvar(nlp.mp)
+  m = NLPModels.get_ncon(nlp.mp)
+  nnzj = NLPModels.get_nnzj(nlp.mp)
+  lcon = NLPModels.get_lcon(nlp.mp)
+  lvar = NLPModels.get_lvar(nlp.mp)
+
+  vals_reg = view(vals, 1:nnzj)
+  NLPModels.jac_coord!(nlp.mp, x, vals_reg)
+
+  cnt = nnzj
+
+  c = nlp.buffer_c2
+  NLPModels.cons!(nlp.mp, x, c)
+
+  # Add contribution of complementarity constraints
+  n_cc = nlp.mp.meta.n_cc
+  cvar = nlp.mp.meta.cvar
+  v = nlp.buffer_c1
+  Jv = nlp.buffer_vars
+  for i in 1:n_cc
+    fill!(v, 0.0)
+    fill!(Jv, 0.0)
+    ic = nlp.ind_cc_cons[i]
+    v[ic] = 1.0
+    NLPModels.jtprod!(nlp.mp, x, v, Jv)
+    # Unpack Jv
+    for k in nlp.Jccp[i]:nlp.Jccp[i+1]-1
+      cnt += 1
+      j = nlp.Jccj[k]
+      if nlp.Jccv[k] >= 1
+        # Terms Diag(x) ∇g(x)
+        vals[cnt] = (x[cvar[ic]] - lvar[cvar[ic]]) * Jv[j]
+      else
+        # Terms Diag(g(x))
+        vals[cnt] = (c[ic] - lcon[ic])
+      end
+    end
+  end
+  return vals
+end
+
+function NLPModels.jprod!(
+  nlp::AmplMPECModel,
+  x::AbstractVector,
+  v::AbstractVector,
+  Jv::AbstractVector,
+)
+  @lencheck nlp.meta.nvar x v
+  @lencheck nlp.meta.ncon Jv
+
+  n_cc = nlp.mp.meta.n_cc
+  cvar = nlp.mp.meta.cvar
+
+  m = NLPModels.get_ncon(nlp.mp)
+  lcon = NLPModels.get_lcon(nlp.mp)
+  lvar = NLPModels.get_lvar(nlp.mp)
+
+  Jv_buf = nlp.buffer_c1
+
+  NLPModels.jprod!(nlp.mp, x, v, Jv_buf)
+  Jv[1:m] .= Jv_buf
+
+  # Add contribution of complementarity constraints
+  c = nlp.buffer_c2
+  NLPModels.cons!(nlp.mp, x, c)
+  for i in 1:n_cc
+    ic = nlp.ind_cc_cons[i]
+    xj = x[cvar[ic]] - lvar[cvar[ic]]
+    Jv[m + i] = Jv[ic] * xj + (c[ic] - lcon[ic]) * v[cvar[ic]]
+  end
+
+  return Jv
+end
+
+function NLPModels.jtprod!(
+  nlp::AmplMPECModel,
+  x::AbstractVector,
+  v::AbstractVector,
+  Jtv::AbstractVector,
+)
+  @lencheck nlp.meta.nvar x Jtv
+  @lencheck nlp.meta.ncon v
+
+  m = NLPModels.get_ncon(nlp.mp)
+  lcon = NLPModels.get_lcon(nlp.mp)
+  lvar = NLPModels.get_lvar(nlp.mp)
+
+  n_cc = nlp.mp.meta.n_cc
+  cvar = nlp.mp.meta.cvar
+
+  v_buf = nlp.buffer_c1
+  v_buf .= @view v[1:m]
+  for i in 1:n_cc
+    ic = nlp.ind_cc_cons[i]
+    v_buf[ic] += (x[cvar[ic]] - lvar[cvar[ic]])
+  end
+  NLPModels.jtprod!(nlp.mp, x, v_buf, Jtv)
+
+  # Add contribution of complementarity constraints
+  c = nlp.buffer_c2
+  NLPModels.cons!(nlp.mp, x, c)
+  for i in 1:n_cc
+    ic = nlp.ind_cc_cons[i]
+    Jtv[cvar[ic]] += (c[ic] - lcon[ic])
+  end
+  return Jtv
+end
+
+function NLPModels.hess_structure!(
+  nlp::AmplMPECModel,
+  hrows::AbstractVector,
+  hcols::AbstractVector,
+)
+  n = NLPModels.get_nvar(nlp.mp)
+  n_cc = nlp.mp.meta.n_cc
+  cvar = nlp.mp.meta.cvar
+  # Evaluate Hessian structure of original model
+  nnzh = NLPModels.get_nnzh(nlp.mp)
+  rows_reg, cols_reg = view(hrows, 1:nnzh), view(hcols, 1:nnzh)
+  NLPModels.hess_structure!(nlp.mp, rows_reg, cols_reg)
+
+  cnt = nnzh
+  # Add complementarity contributions ∇g(x)' ∇h(x) + ∇h(x)' ∇g(x)
+  # with h(x) := x[cvar[icc]]
+  for i in 1:n_cc
+    ic = nlp.ind_cc_cons[i]
+    for k in nlp.Jccp[i]:nlp.Jccp[i+1]-1
+      j = nlp.Jccj[k]
+      # Only store lower-triangular entries
+      if nlp.Jccv[k] >= 1
+        if cvar[ic] >= j
+          cnt += 1
+          hrows[cnt] = cvar[ic]
+          hcols[cnt] = j
+        else
+          cnt += 1
+          hrows[cnt] = j
+          hcols[cnt] = cvar[ic]
+        end
+      end
+    end
+  end
+  return hrows, hcols
+end
+
+function NLPModels.hess_coord!(
+    nlp::AmplMPECModel,
+    x::AbstractVector,
+    vals::AbstractVector;
+    obj_weight::Real=one(eltype(x)),
+)
+  @lencheck nlp.meta.nvar x
+  @lencheck nlp.meta.nnzh vals
+  NLPModels.hess_coord!(nlp.mp, x, vals; obj_weight=obj_weight)
+  return vals
+end
+
+function NLPModels.hess_coord!(
+  nlp::AmplMPECModel,
+  x::AbstractVector,
+  y::AbstractVector,
+  vals::AbstractVector;
+  obj_weight::Real=one(eltype(x)),
+)
+  @lencheck nlp.meta.nvar x
+  @lencheck nlp.meta.ncon y
+  @lencheck nlp.meta.nnzh vals
+
+  m = NLPModels.get_ncon(nlp.mp)
+  lvar = NLPModels.get_lvar(nlp.mp)
+  nnzh = NLPModels.get_nnzh(nlp.mp)
+  n_cc = nlp.mp.meta.n_cc
+  cvar = nlp.mp.meta.cvar
+
+  y_buf = nlp.buffer_c1
+  y_buf .= @view y[1:m]
+  for i in 1:n_cc
+    ic = nlp.ind_cc_cons[i]
+    y_buf[ic] += y[m + i] * (x[cvar[ic]] - lvar[cvar[ic]])
+  end
+  NLPModels.hess_coord!(nlp.mp, x, y_buf, vals; obj_weight=obj_weight)
+  # Add complementarity contributions
+  jac_buf = nlp.buffer_jac
+  NLPModels.jac_coord!(nlp.mp, x, jac_buf)
+  cnt = nnzh
+  for i in 1:n_cc
+    ic = nlp.ind_cc_cons[i]
+    mul_i = y[m + i]
+    for k in nlp.Jccp[i]:nlp.Jccp[i+1]-1
+      j = nlp.Jccj[k]
+      if nlp.Jccv[k] >= 1
+        if cvar[ic] >= j
+          cnt += 1
+          coef = (cvar[ic] == j) ? 2.0 : 1.0
+          vals[cnt] = coef * mul_i * jac_buf[nlp.Jccv[k]]
+        else
+        end
+      end
+    end
+  end
+  return vals
+end
+

--- a/test/ampl_mpec_test.jl
+++ b/test/ampl_mpec_test.jl
@@ -1,0 +1,102 @@
+
+using Test
+using NLPModels
+using AmplNLReader
+using LinearAlgebra
+using SparseArrays
+
+function test_mpec_wrapper(nlp)
+    mp = AmplNLReader.AmplMPECModel(nlp)
+
+    n = NLPModels.get_nvar(nlp)
+    m = NLPModels.get_ncon(nlp)
+    nnzj = NLPModels.get_nnzj(nlp)
+    lvar = NLPModels.get_lvar(nlp)
+    lcon = NLPModels.get_lcon(nlp)
+    # Complementarity structure
+    n_cc = nlp.meta.n_cc
+    cvar = nlp.meta.cvar
+    icc = mp.ind_cc_cons
+
+    x0 = ones(n)
+
+    # Test problems dimensions
+    @test n == NLPModels.get_nvar(mp)
+    @test NLPModels.get_ncon(nlp) + n_cc == NLPModels.get_ncon(mp)
+
+    # Test objective and gradient match
+    @test NLPModels.obj(nlp, x0) == NLPModels.obj(mp, x0)
+    @test NLPModels.grad(nlp, x0) == NLPModels.grad(mp, x0)
+
+    # Test evaluation of constraints
+    ixc = cvar[icc]
+    c = NLPModels.cons(nlp, x0)
+    c_cc = NLPModels.cons(mp, x0)
+    @test c_cc == [c ; (x0[ixc] .- lvar[ixc]) .* (c[icc] .- lcon[icc])]
+
+    # Test evaluation of Jacobian
+    (I, J) = NLPModels.jac_structure(nlp)
+    V = zeros(nnzj)
+    # Evaluate Jacobian without complementarities
+    NLPModels.jac_coord!(nlp, x0, V)
+    jac_nlp = sparse(I, J, V)  # original Jacobian
+    # Evaluate Jacobian with complementarities
+    nnzj_cc = NLPModels.get_nnzj(mp)
+    (I_cc, J_cc) = NLPModels.jac_structure(mp)
+    V_cc = zeros(nnzj_cc)
+    NLPModels.jac_coord!(mp, x0, V_cc)
+    jac_cc = sparse(I_cc, J_cc, V_cc)  # Jacobian with complementarities
+    @test size(jac_cc) == (m + n_cc, n)
+    # Test non-complementarity part matches original Jacobian
+    @test jac_cc[1:m, :] == jac_nlp
+    # Test Jacobian of complementarity part
+    # ∇(Diag(g(x)) x) = Diag(g(x)) + Diag(x) * ∇g(x)
+    G = Diagonal(c[icc] .- lcon[icc])
+    H = Diagonal(x0[ixc] .- lvar[ixc])
+    ∇G = jac_nlp[icc, :]
+    ∇H = sparse(1:n_cc, ixc, ones(n_cc), n_cc, n)
+    @test jac_cc[m+1:m+n_cc, :] == G * ∇H + H * ∇G
+
+    # jtprod
+    v = ones(m + n_cc)
+    Jtv = zeros(n)
+    NLPModels.jtprod!(mp, x0, v, Jtv)
+    @test Jtv ≈ jac_cc' * v
+
+    # jprod
+    v = ones(n)
+    Jv = zeros(m + n_cc)
+    NLPModels.jprod!(mp, x0, v, Jv)
+    @test Jv ≈ jac_cc * v
+
+    # Hessian
+    y = ones(m)
+    (I, J) = NLPModels.hess_structure(nlp)
+    # Evaluate original Hessian
+    nnzh = NLPModels.get_nnzh(nlp)
+    hvals = zeros(nnzh)
+    NLPModels.hess_coord!(nlp, x0, y, hvals)
+    hess_nlp = sparse(I, J, hvals, n, n)
+    # Evaluate Hessian with complementarity constraints
+    y_cc = ones(m + n_cc)
+    (I_cc, J_cc) = NLPModels.hess_structure(mp)
+    nnzh_cc = NLPModels.get_nnzh(mp)
+    hvals_cc = zeros(nnzh_cc)
+    NLPModels.hess_coord!(mp, x0, y_cc, hvals_cc)
+    hess_cc = sparse(I_cc, J_cc, hvals_cc, n, n)
+    # Test expression is correct
+    y .= 0.0
+    y[icc] .= (x0[ixc] .- lvar[ixc])
+    hvals_tmp = zeros(nnzh)
+    NLPModels.hess_coord!(nlp, x0, y, hvals_tmp; obj_weight=0.0)
+    ∇2G = sparse(I, J, hvals_tmp, n, n)
+    D = Diagonal(y_cc[m+1:m+n_cc])
+    JtJ = LowerTriangular(∇G' * D * ∇H + ∇H' * D * ∇G)
+    @test hess_cc == hess_nlp + ∇2G + JtJ
+    return
+end
+
+path = joinpath(dirname(@__FILE__), "problems")
+instance = "bard1.nl"
+nlp = AmplModel(joinpath(path, instance))
+test_mpec_wrapper(nlp)

--- a/test/problems/bard1.nl
+++ b/test/problems/bard1.nl
@@ -1,0 +1,66 @@
+g9 4 1 0 4 20081213 0 4 0 240	# problem tmp
+ 5 4 1 0 1	# vars, constraints, objectives, ranges, eqns
+ 0 1 3 0	# nonlinear constrs, objs; ccons: lin, nonlin
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 11 2	# nonzeros in Jacobian, gradients
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+C1
+n-3
+C2
+n4
+C3
+n7
+O0 0
+o0
+o5
+o0
+n-5
+v0
+n2
+o5
+o0
+n1
+o2
+n2
+v1
+n2
+r
+4 2
+5 1 3
+5 1 4
+5 1 5
+b
+2 0
+2 0
+2 0
+2 0
+2 0
+k4
+4
+8
+9
+10
+J0 5
+0 -1.5
+1 2
+2 1
+3 -0.5
+4 1
+J1 2
+0 3
+1 -1
+J2 2
+0 -1
+1 0.5
+J3 2
+0 -1
+1 -1
+G0 2
+0 0
+1 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,4 @@ using AmplNLReader, LinearAlgebra, NLPModels, NLPModelsTest, SparseArrays, Test
 
 include("ampl_test.jl")
 include("consistency.jl")
+include("ampl_mpec_test.jl")


### PR DESCRIPTION
This PR is an attempt to support complementarity constraints, following #37 

It introduces three modifications: 
- the number of complementarity constraints `n_cc` and positions `cvar` are imported from Ampl using `asl_n_cc` and `asl_cvar`, respectively. 
- both `n_cc` and `cvar` are stored in `AmplNLPMeta` 
- a wrapper `AmplMPECModel` implements a smooth reformulation of the complementarity constraints. 

The constraints 
```
x_L <= x complements g(x) >= g_L 
```
is reformulated as 
```
x_L <= x 
g_L <= g(x)
Diag(g(x)) * x <= 0 
```
We can think of implementing other smooth reformulations. 

`AmplMPECModel` adds some complexity to the package, and it could be appropriate to move this wrapper in a second package once NLPModels has a proper support for complementarity constraints. 

Cc @tmigot @dpo 