### PR TITLE
Bump to NLPModels 0.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 ASL_jll = "0.1.3"
-NLPModels = "0.18"
+NLPModels = "0.19"
 julia = "1.6.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 
 [compat]
 Documenter = "1.0"
-NLPModels = "0.18"
+NLPModels = "0.19"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,6 +11,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ASL_jll = "^0.1.1"
-NLPModels = "0.18"
-NLPModelsModifiers = "0.5"
-NLPModelsTest = "0.6"
+NLPModels = "0.19"
+NLPModelsModifiers = "0.7"
+NLPModelsTest = "0.9"

--- a/test/consistency.jl
+++ b/test/consistency.jl
@@ -6,7 +6,7 @@
       nlp_man = eval(Symbol(problem))()
       nlps = [nlp_ampl, nlp_man]
 
-      consistent_nlps(nlps)
+      consistent_nlps(nlps; test_slack = false)
     end
   end
 end


### PR DESCRIPTION
Because #127 is not implemented, SlackModels are not compatible with AmplNLReader